### PR TITLE
server.js: Fix adding logger for newer winston instances

### DIFF
--- a/server.js
+++ b/server.js
@@ -29,7 +29,7 @@ if (config.logging) {
     detail = config.logging[i];
     type = detail.type;
     delete detail.type;
-    winston.add(winston.transports[type], detail);
+    winston.add(new winston.transports[type], detail);
   }
 }
 


### PR DESCRIPTION
haste-server crashes with newer winston versions. This fixes it.