### PR TITLE
LFT-2320: npm ci/install --ignore-scripts in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,12 @@ WORKDIR /usr/src/app
 
 COPY --chown=node:node . .
 
-RUN npm install && \
-    npm install redis@0.8.1 && \
-    npm install pg@8.11.3 && \
-    npm install memcached@2.2.2 && \
-    npm install aws-sdk@2.814.0 && \
-    npm install rethinkdbdash@2.3.31
+RUN npm install --ignore-scripts && \
+    npm install --ignore-scripts redis@0.8.1 && \
+    npm install --ignore-scripts pg@8.11.3 && \
+    npm install --ignore-scripts memcached@2.2.2 && \
+    npm install --ignore-scripts aws-sdk@2.814.0 && \
+    npm install --ignore-scripts rethinkdbdash@2.3.31
 
 ENV STORAGE_TYPE=memcached \
     STORAGE_HOST=127.0.0.1 \


### PR DESCRIPTION
Apply --ignore-scripts to npm ci and install commands within Dockerfiles. This has not been tested, moreso acting as a prompt for the project owner to evaluate and apply as appropriate.